### PR TITLE
cli: --list cmd and requirements improvements

### DIFF
--- a/stf_appium_client/StfClient.py
+++ b/stf_appium_client/StfClient.py
@@ -155,7 +155,7 @@ class StfClient(Logger):
         device['owner'] = None
         self.logger.info(f'{serial}: released')
 
-    def list_devices(self, requirements: str, fields: str = ""):
+    def list_devices(self, requirements: dict, fields: str = ""):
         req_keys = list(requirements.keys())
         req_keys.extend(['present', 'ready', 'using', 'owner'])
         req_keys.extend([

--- a/stf_appium_client/StfClient.py
+++ b/stf_appium_client/StfClient.py
@@ -166,6 +166,7 @@ class StfClient(Logger):
         fields = uniq(req_keys)
 
         predicate = requirements.copy()
+
         predicate.update(
             dict(
                 present=True,

--- a/stf_appium_client/StfClient.py
+++ b/stf_appium_client/StfClient.py
@@ -155,7 +155,13 @@ class StfClient(Logger):
         device['owner'] = None
         self.logger.info(f'{serial}: released')
 
-    def list_devices(self, requirements: dict, fields: str = ""):
+    def list_devices(self, requirements: dict, fields: str = "") -> list:
+        """
+        Get list of devices filtered by given requirements and optional extra fields
+        :param requirements: filter dictionary
+        :param fields: extra fields to include
+        :return: list of objects that represent devices
+        """
         req_keys = list(requirements.keys())
         req_keys.extend(['present', 'ready', 'using', 'owner'])
         req_keys.extend([

--- a/stf_appium_client/cli.py
+++ b/stf_appium_client/cli.py
@@ -40,6 +40,9 @@ def main():
     parser.add_argument('--requirements', metavar='R', type=str,
                         default="{}",
                         help='requirements as json string')
+    parser.add_argument('--list',
+                        action='store_true',
+                        help='Only list devices as json')
     parser.add_argument('--timeout', metavar='t', type=int,
                         default=StfClient.DEFAULT_ALLOCATION_TIMEOUT_SECONDS,
                         help='allocation timeout')
@@ -63,6 +66,11 @@ def main():
 
     client = StfClient(host=args.host)
     client.connect(token=args.token)
+
+    if args.list:
+        print(client.list_devices(requirements=requirement))
+        exit(0)
+
     with client.allocation_context(requirements=requirement,
                                    wait_timeout=args.wait_timeout,
                                    timeout_seconds=args.timeout) as device:
@@ -103,7 +111,7 @@ def main():
                         proc.communicate()
                         returncode = proc.returncode
                 except Exception as error:
-                    appium.logger.error(error)
+                    client.logger.error(error)
         except Exception as error:
             client.logger.error(error)
     exit(returncode)

--- a/stf_appium_client/tools.py
+++ b/stf_appium_client/tools.py
@@ -28,6 +28,8 @@ def parse_requirements(requirements_str: str) -> dict:
     if isinstance(requirements_str, dict):
         return requirements_str
     assert isinstance(requirements_str, str), 'Invalid requirements type'
+    if requirements_str == "":
+        return dict()
     try:
         return json.loads(requirements_str)
     except json.decoder.JSONDecodeError:

--- a/stf_appium_client/tools.py
+++ b/stf_appium_client/tools.py
@@ -39,5 +39,15 @@ def parse_requirements(requirements_str: str) -> dict:
             key, value = part.split('=')
             if not (key and value):
                 raise ValueError('value or key missing')
-            requirements[key] = value
+
+            def split(dest, subkey):
+                if '.' in subkey:
+                    keys = subkey.split('.')
+                    key1 = keys[0]
+                    rest = '.'.join(keys[1:])
+                    dest[key1] = {}
+                    split(dest[key1], rest)
+                else:
+                    dest[subkey] = value
+            split(requirements, key)
         return requirements

--- a/test/test_StfClient.py
+++ b/test/test_StfClient.py
@@ -50,6 +50,7 @@ class TestStfClientBasics(unittest.TestCase):
         self.assertIsInstance(client.find_wait_and_allocate, types.MethodType)
         self.assertIsInstance(client.find_and_allocate, types.MethodType)
         self.assertIsInstance(client.allocation_context, types.MethodType)
+        self.assertIsInstance(client.list_devices, types.MethodType)
 
     @patch('stf_appium_client.StfClient.swagger_uri', new_callable=PropertyMock)
     def test(self, mock_swagger_uri):
@@ -105,6 +106,12 @@ class TestStfClient(unittest.TestCase):
 
         with self.assertRaises(DeviceNotFound):
             self.client.find_and_allocate({})
+
+    def test_list_devices(self):
+        available = {'serial': 123, 'present': True, 'ready': True, 'using': False, 'owner': None}
+        self.client.get_devices = MagicMock(return_value=[available])
+        response = self.client.list_devices(requirements={})
+        self.assertEqual(response, [available])
 
     def test_find_and_allocate_success(self):
         available = {'serial': 123, 'present': True, 'ready': True, 'using': False, 'owner': None}

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,5 +1,6 @@
 import unittest
-from stf_appium_client.tools import find_free_port
+import json
+from stf_appium_client.tools import find_free_port, parse_requirements
 
 
 class TestTools(unittest.TestCase):
@@ -8,3 +9,9 @@ class TestTools(unittest.TestCase):
         for i in range(10):
             port = find_free_port()
             self.assertTrue(isinstance(port, int))
+
+    def test_parse_requirements(self):
+        req = {"test": {"a": "1"}}
+        self.assertEqual(parse_requirements(json.dumps(req)), req)
+        self.assertEqual(parse_requirements("test.a=1"), req)
+        self.assertEqual(parse_requirements("test=1"), {"test": "1"})

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -11,7 +11,17 @@ class TestTools(unittest.TestCase):
             self.assertTrue(isinstance(port, int))
 
     def test_parse_requirements(self):
+        self.assertEqual(parse_requirements("test=1"), {"test": "1"})
+        self.assertEqual(parse_requirements(""), {})
+        self.assertEqual(parse_requirements({}), {})
+
         req = {"test": {"a": "1"}}
         self.assertEqual(parse_requirements(json.dumps(req)), req)
         self.assertEqual(parse_requirements("test.a=1"), req)
-        self.assertEqual(parse_requirements("test=1"), {"test": "1"})
+        self.assertEqual(parse_requirements("test.a=1"), req)
+        self.assertEqual(parse_requirements("test.a.b=1"), {"test": {"a": {"b": "1"}}})
+
+        with self.assertRaises(ValueError):
+            self.assertEqual(parse_requirements("key="), {})
+        with self.assertRaises(ValueError):
+            self.assertEqual(parse_requirements("="), {})


### PR DESCRIPTION
* add cli argument `--list` which prints available devices filtered by given requirements
* improve device requirements parser to support nested keys (`--requirements group.name=test`)
  * note: json format already supports nested objects