### PR TITLE
improve appium integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,15 @@ positional arguments:
   command           Command to be execute during device allocation
 
 optional arguments:
-  -h, --help        show this help message and exit
-  --token TOKEN     openstf access token
-  --host HOST       openstf host
-  --list l          list only requirements, filtered on given requirements
-  --requirements R  requirements as json string
-  --timeout t       allocation timeout
-  --wait_timeout w  max wait time for suitable device allocation
+  -h, --help          show this help message and exit
+  --token TOKEN       openstf access token
+  --host HOST         openstf host
+  --list              list only requirements, filtered on given requirements
+  --requirements R    requirements as json string
+  --timeout t         allocation timeout
+  --wait_timeout w    max wait time for suitable device allocation
+  --verbose           appium logs to console. WARNING: this mix console prints
+  --appium-logs file  appium logs to file
 
 ```
 

--- a/stf_appium_client/Appium.py
+++ b/stf_appium_client/Appium.py
@@ -1,3 +1,4 @@
+from typing import Any, List
 import atexit
 from appium.webdriver.appium_service import AppiumService
 from stf_appium_client.tools import find_free_port
@@ -6,11 +7,13 @@ from stf_appium_client.Logger import Logger
 
 class Appium(Logger):
 
-    def __init__(self):
+    def __init__(self, appium_args: List[str] = None, **kwargs: Any):
         """ Initialize Appium wrapper """
         super().__init__()
         self.port = find_free_port()
         self.service = AppiumService()
+        self._extra_args = kwargs
+        self._appium_args = appium_args or []
 
         @atexit.register
         def _exit():
@@ -28,8 +31,9 @@ class Appium(Logger):
         assert not self.service.is_running, 'Appium already running'
         # https://appium.io/docs/en/writing-running-appium/server-args/
         args = ['-a', '127.0.0.1', '-p', f"{self.port}"]
-        self.logger.info(f'Start Appium with args: {" ".join(args)}')
-        self.service.start(args=args)
+        args.extend(self._appium_args)
+        self.logger.info(f'Start Appium with args: {" ".join(args)} {self._extra_args}')
+        self.service.start(args=args, **self._extra_args)
         assert self.service.is_running, 'Appium did not started :o'
         uri = self.get_wd_hub_uri()
         self.logger.info(f'Appium started: {uri} (pid: {self.service._process.pid})')

--- a/stf_appium_client/cli.py
+++ b/stf_appium_client/cli.py
@@ -1,5 +1,5 @@
 #! python3
-
+from subprocess import PIPE
 import argparse
 import json
 import os
@@ -49,6 +49,8 @@ def main():
     parser.add_argument('--wait_timeout', metavar='w', type=int,
                         default=60,
                         help='max wait time for suitable device allocation')
+    parser.add_argument('--verbose', action="store_true",
+                        help='verbose appium logging')
     parser.add_argument('command', nargs='*',
                         help='Command to be execute during device allocation')
 
@@ -78,7 +80,8 @@ def main():
             with AdbServer(device['remote_adb_url']) as adb:
                 adb.logger.info(f'adb server listening localhost:{adb.port}')
                 try:
-                    with Appium() as appium:
+                    extra_args = dict(stdout=PIPE, stderr=PIPE) if args.verbose else {}
+                    with Appium(appium_args=['--log', 'appium.log'], extra_args=extra_args) as appium:
                         appium.logger.info(f"appium server listening localhost:{appium.port}")
 
                         appium.logger.info(f'Device in use: {device.manufacturer}:{device.marketName}, model: {device.model}, sn: {device.serial}')

--- a/stf_appium_client/cli.py
+++ b/stf_appium_client/cli.py
@@ -50,9 +50,9 @@ def main():
                         default=60,
                         help='max wait time for suitable device allocation')
     parser.add_argument('--verbose', action="store_true",
-                        help='verbose appium logging')
-    parser.add_argument('--appium-logs', type=str, default='appium.log',
-                        help='appium logs file')
+                        help='appium logs to console. WARNING: this mix console prints')
+    parser.add_argument('--appium-logs', metavar='file', type=str, default='',
+                        help='appium logs to file')
     parser.add_argument('command', nargs='*',
                         help='Command to be execute during device allocation')
 

--- a/stf_appium_client/cli.py
+++ b/stf_appium_client/cli.py
@@ -51,6 +51,8 @@ def main():
                         help='max wait time for suitable device allocation')
     parser.add_argument('--verbose', action="store_true",
                         help='verbose appium logging')
+    parser.add_argument('--appium-logs', type=str, default='appium.log',
+                        help='appium logs file')
     parser.add_argument('command', nargs='*',
                         help='Command to be execute during device allocation')
 
@@ -80,8 +82,11 @@ def main():
             with AdbServer(device['remote_adb_url']) as adb:
                 adb.logger.info(f'adb server listening localhost:{adb.port}')
                 try:
-                    extra_args = dict(stdout=PIPE, stderr=PIPE) if args.verbose else {}
-                    with Appium(appium_args=['--log', 'appium.log'], extra_args=extra_args) as appium:
+                    extra_args = dict(stdout=sys.stdout.fileno(), stderr=sys.stderr.fileno()) if args.verbose else {}
+                    appium_args = []
+                    if args.appium_logs:
+                        appium_args.extend(['--log', args.appium_logs])
+                    with Appium(appium_args=appium_args, **extra_args) as appium:
                         appium.logger.info(f"appium server listening localhost:{appium.port}")
 
                         appium.logger.info(f'Device in use: {device.manufacturer}:{device.marketName}, model: {device.model}, sn: {device.serial}')


### PR DESCRIPTION
Appium object takes optional appium_args and kwargs that is used for Appium service [start call](https://github.com/appium/python-client/blob/91a9d6701430599637bb6895f9ffb078ee4bd052/appium/webdriver/appium_service.py#L122).

new optional `stf` command arguments:
* `--appium-logs <filename>`. default filename: `appium.logs`
    store appium process logs to file.
* `--verbose` 
   pipe all appium prints to console. **NOTE**: this potentially mix console output with subprocess prints and this tool logs. 