### PR TITLE
change AdbServer:execute to public

### DIFF
--- a/stf_appium_client/AdbServer.py
+++ b/stf_appium_client/AdbServer.py
@@ -6,7 +6,6 @@ from stf_appium_client.tools import find_free_port, assert_tool_exists
 
 
 class AdbServer(Logger):
-    EasyProcess = EasyProcess
     def __init__(self, adb_server: str = None, port: int = None):
         """
         Connect to adb server and open proxy for given port
@@ -59,7 +58,7 @@ class AdbServer(Logger):
         """ Get local adb server port """
         return self._port
 
-    def _execute(self, command: str, timeout: int = 2):
+    def execute(self, command: str, timeout: int = 2):
         """
         Internal execute function
         :param command: adb command to be execute
@@ -72,7 +71,7 @@ class AdbServer(Logger):
         my_env = os.environ.copy()
         if "ADB_VENDOR_KEYS" not in my_env:
             my_env["ADB_VENDOR_KEYS"] = "~/.android"
-        response = AdbServer.EasyProcess(cmd, env=my_env).call(timeout=timeout)
+        response = EasyProcess(cmd, env=my_env).call(timeout=timeout)
         self.logger.debug(f'adb stdout: {response.stdout}')
         return response
 
@@ -86,7 +85,7 @@ class AdbServer(Logger):
         self.logger.debug(f'adb({self._adb_server}): connecting')
         try:
             cmd = f"connect {self._adb_server}"
-            response = self._execute(cmd, 10)
+            response = self.execute(cmd, 10)
             stdout = response.stdout
             self.logger.debug(stdout)
             assert response.return_code == 0, f"{response.stderr}"
@@ -102,7 +101,7 @@ class AdbServer(Logger):
         assert self.connected, 'adb is not started'
         try:
             self.logger.debug(f'adb({self.port}): killing service')
-            self._execute('kill-server')
+            self.execute('kill-server')
             self.connected = False
         except AssertionError as error:
             self.logger.error(f'adb kill failed: {error}')

--- a/stf_appium_client/AdbServer.py
+++ b/stf_appium_client/AdbServer.py
@@ -58,12 +58,12 @@ class AdbServer(Logger):
         """ Get local adb server port """
         return self._port
 
-    def execute(self, command: str, timeout: int = 2):
+    def execute(self, command: str, timeout: int = 2) -> EasyProcess:
         """
         Internal execute function
-        :param command: adb command to be execute
+        :param command: adb command to be executed
         :param timeout: command timeout
-        :return: EasyProcess instance which contains stdout, stderr and return_code
+        :return: EasyProcess instance which contains stdout, stderr, return_code, timeout_happened
         """
         port = f"-P {self.port} " if self.port else ""
         cmd = f"adb {port} {command}"

--- a/test/test_AdbServer.py
+++ b/test/test_AdbServer.py
@@ -65,7 +65,7 @@ class TestAdbServer:
             python = sys.executable
             return EasyProcess([python, "-c", 'import time\ntime.sleep(10)']).call(timeout=timeout)
         mock_easy_process.return_value.call.side_effect = call
-        adb_server = AdbServer('locvalhost', port=1000)
+        adb_server = AdbServer('localhost', port=1000)
         resp = adb_server.execute('hello', timeout=0.1)
         assert resp.timeout_happened
         assert resp.return_code == -15

--- a/test/test_AdbServer.py
+++ b/test/test_AdbServer.py
@@ -68,5 +68,4 @@ class TestAdbServer:
         adb_server = AdbServer('localhost', port=1000)
         resp = adb_server.execute('hello', timeout=0.1)
         assert resp.timeout_happened
-        assert resp.return_code == -15
         mock_easy_process.assert_called_once()

--- a/test/test_AdbServer.py
+++ b/test/test_AdbServer.py
@@ -1,5 +1,6 @@
 import logging
 from shutil import which
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -16,8 +17,40 @@ class TestAdbServer:
     def teardown_classr(cls):
         logging.disable(logging.NOTSET)
 
-    def test_context(self):
+    def test_context_e2e(self):
         if not which("adb"):
             pytest.skip("adb is missing!")
         with AdbServer('localhost') as adb:
             assert isinstance(adb.port, int)
+
+    @patch('shutil.which')
+    @patch('stf_appium_client.AdbServer.EasyProcess')
+    def test_context(self, mock_easy_process, mock_which):
+        mock_easy_process.return_value.call.return_value.stdout = ''
+        mock_easy_process.return_value.call.return_value.return_code = 0
+        with AdbServer('localhost') as adb:
+            assert isinstance(adb.port, int)
+
+    @patch('stf_appium_client.AdbServer.EasyProcess')
+    def test_execute_success(self, mock_easy_process):
+        mock_easy_process.return_value.call.return_value.stdout = '123'
+        mock_easy_process.return_value.call.return_value.return_code = 0
+        adb_server = AdbServer('locvalhost', port=1000)
+        resp = adb_server.execute('hello', 10)
+        assert resp.return_code == 0
+        assert resp.stdout == '123'
+        mock_easy_process.assert_called_once()
+        mock_easy_process.return_value.call.assert_called_once_with(timeout=10)
+
+    @patch('stf_appium_client.AdbServer.EasyProcess')
+    def test_execute_fail(self, mock_easy_process):
+        mock_easy_process.return_value.call.return_value.stderr = 'abc'
+        mock_easy_process.return_value.call.return_value.stdout = '123'
+        mock_easy_process.return_value.call.return_value.return_code = 1
+        adb_server = AdbServer('locvalhost', port=1000)
+        resp = adb_server.execute('hello', 10)
+        assert resp.return_code == 1
+        assert resp.stdout == '123'
+        assert resp.stderr == 'abc'
+        mock_easy_process.assert_called_once()
+        mock_easy_process.return_value.call.assert_called_once_with(timeout=10)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -24,8 +24,9 @@ class TestAdbServer:
                 main()
         assert cm.value.code == 1
 
-    def test_host_not_found(self):
+    @patch('shutil.which')
+    def test_host_not_found(self, mock_which):
         testargs = ["prog", "--token", "123", "--host", "http://test"]
-        with pytest.raises(urllib3.exceptions.MaxRetryError) as error:
+        with pytest.raises(urllib3.exceptions.MaxRetryError):
             with patch.object(sys, 'argv', testargs):
                 main()


### PR DESCRIPTION
allow to execute adb commands by user.

Usage:

```python
adb_server = AdbServer('localhost', port=1000)
resp = adb_server.execute('hello', timeout=0.1)
print(resp.stdout)
print(resp.stderr)
print(resp.return_code)
print(resp.timeout_happened)
```