### PR TITLE
accept 403 (ForbiddenException) when trying to allocate

### DIFF
--- a/stf_appium_client/StfClient.py
+++ b/stf_appium_client/StfClient.py
@@ -4,6 +4,9 @@ import random
 import json
 from pydash import filter_, map_, wrap, find, uniq
 import atexit
+
+from stf_client.exceptions import ForbiddenException
+
 from stf_appium_client.Logger import Logger
 from stf_appium_client.exceptions import DeviceNotFound, NotConnectedError
 from stf_client.api_client import ApiClient, Configuration
@@ -197,7 +200,7 @@ class StfClient(Logger):
             def try_allocate(device):
                 try:
                     return self.allocate(device, timeout_seconds=timeout_seconds)
-                except AssertionError as error:
+                except (AssertionError, ForbiddenException) as error:
                     self.logger.warning(f"{device.get('serial')}Allocation fails: {error}")
                     return None
 

--- a/test/test_StfClient.py
+++ b/test/test_StfClient.py
@@ -2,6 +2,9 @@ import unittest
 import logging
 import types
 from unittest.mock import patch, MagicMock
+
+from stf_client.exceptions import ForbiddenException
+
 from stf_appium_client.StfClient import StfClient
 from stf_appium_client.exceptions import *
 
@@ -134,12 +137,12 @@ class TestStfClient(unittest.TestCase):
     def test_find_and_allocate_second_success(self, mock_choise):
         invalid = {'serial': '12', 'present': False, 'ready': True, 'using': False, 'owner': None, 'status': 3}
         available = {'serial': '123', 'present': True, 'ready': True, 'using': False, 'owner': None, 'status': 3}
-        self.client.get_devices = MagicMock(return_value=[invalid, available])
+        self.client.get_devices = MagicMock(return_value=[invalid, available, available])
 
         def dummy_alloc(dev, timeout_seconds):
             return dev
 
-        self.client.allocate = MagicMock(side_effect=dummy_alloc)
+        self.client.allocate = MagicMock(side_effect=[ForbiddenException, dummy_alloc])
 
         device = self.client.find_and_allocate({})
         available['owner'] = 'me'


### PR DESCRIPTION
fix case when somebody has already allocated resources at the same time when trying to allocate :
```
E   stf_client.exceptions.ForbiddenException: Status Code: 403
```