### PR TITLE
handle ForbiddenException when atexit release

### DIFF
--- a/stf_appium_client/StfClient.py
+++ b/stf_appium_client/StfClient.py
@@ -89,10 +89,7 @@ class StfClient(Logger):
                 if device.get('owner') == "me":
                     self.logger.info(f"exit:Release device {device.get('serial')}")
                     self.release(device)
-            except ForbiddenException as error:
-                # was already released
-                self.logger.debug(f'release forbidden: {error}')
-            except AssertionError as error:
+            except (AssertionError, ForbiddenException) as error:
                 self.logger.error(f'releasing fails: {error}')
 
         return device

--- a/stf_appium_client/StfClient.py
+++ b/stf_appium_client/StfClient.py
@@ -89,6 +89,9 @@ class StfClient(Logger):
                 if device.get('owner') == "me":
                     self.logger.info(f"exit:Release device {device.get('serial')}")
                     self.release(device)
+            except ForbiddenException as error:
+                # was already released
+                self.logger.debug(f'release forbidden: {error}')
             except AssertionError as error:
                 self.logger.error(f'releasing fails: {error}')
 


### PR DESCRIPTION
accept that release during atexit registered release handler can raise. Just trace it. Note that this kinda workaround for root cause, release was not done safety manner.