### PR TITLE
verify return code for adb executes

### DIFF
--- a/stf_appium_client/AdbServer.py
+++ b/stf_appium_client/AdbServer.py
@@ -58,7 +58,7 @@ class AdbServer(Logger):
         """ Get local adb server port """
         return self._port
 
-    def execute(self, command: str, timeout: int = 2, verify: bool = True) -> EasyProcess:
+    def execute(self, command: str, timeout: int = 10, verify: bool = True) -> EasyProcess:
         """
         Internal execute function
         :param command: adb command to be executed
@@ -67,8 +67,8 @@ class AdbServer(Logger):
         :return: EasyProcess instance which contains stdout, stderr, return_code, timeout_happened
         :raise AssertionError: if non 0 is returned or timeout happens and verify=True.
         """
-        port = f"-P {self.port} " if self.port else ""
-        cmd = f"adb {port} {command}"
+        port = f" -P {self.port}" if self.port else ""
+        cmd = f"adb{port} {command}"
         self.logger.debug(f"adb: {cmd}")
         my_env = os.environ.copy()
         if "ADB_VENDOR_KEYS" not in my_env:
@@ -78,7 +78,7 @@ class AdbServer(Logger):
                           f'stdout: {response.stdout}, '
                           f'stderr: {response.stderr}')
         if verify:
-            assert response.timeout_happened, f'adb command timeout ({timeout}s)'
+            assert response.timeout_happened is False, f'adb command "{cmd}" timeout ({timeout}s)'
             assert response.return_code == 0, f'adb command "{cmd}" fails with code: {response.return_code}'
         return response
 

--- a/stf_appium_client/AdbServer.py
+++ b/stf_appium_client/AdbServer.py
@@ -58,12 +58,14 @@ class AdbServer(Logger):
         """ Get local adb server port """
         return self._port
 
-    def execute(self, command: str, timeout: int = 2) -> EasyProcess:
+    def execute(self, command: str, timeout: int = 2, verify: bool = True) -> EasyProcess:
         """
         Internal execute function
         :param command: adb command to be executed
-        :param timeout: command timeout
+        :param timeout: command timeout [s]
+        :param verify: verify return code is 0 of executed adb command, Also timeout causes assert raise.
         :return: EasyProcess instance which contains stdout, stderr, return_code, timeout_happened
+        :raise AssertionError: if non 0 is returned or timeout happens and verify=True.
         """
         port = f"-P {self.port} " if self.port else ""
         cmd = f"adb {port} {command}"
@@ -75,6 +77,9 @@ class AdbServer(Logger):
         self.logger.debug(f'adb retcode: {response.return_code}, '
                           f'stdout: {response.stdout}, '
                           f'stderr: {response.stderr}')
+        if verify:
+            assert response.timeout_happened, f'adb command timeout ({timeout}s)'
+            assert response.return_code == 0, f'adb command "{cmd}" fails with code: {response.return_code}'
         return response
 
     def connect(self) -> None:

--- a/test/test_AdbServer.py
+++ b/test/test_AdbServer.py
@@ -1,8 +1,7 @@
 import logging
 import sys
 from shutil import which
-from time import sleep
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from easyprocess import EasyProcess

--- a/test/test_AdbServer.py
+++ b/test/test_AdbServer.py
@@ -30,6 +30,7 @@ class TestAdbServer:
     def test_context(self, mock_easy_process, mock_which):
         mock_easy_process.return_value.call.return_value.stdout = ''
         mock_easy_process.return_value.call.return_value.return_code = 0
+        mock_easy_process.return_value.call.return_value.timeout_happened = False
         with AdbServer('localhost') as adb:
             assert isinstance(adb.port, int)
 
@@ -37,6 +38,7 @@ class TestAdbServer:
     def test_execute_success(self, mock_easy_process):
         mock_easy_process.return_value.call.return_value.stdout = '123'
         mock_easy_process.return_value.call.return_value.return_code = 0
+        mock_easy_process.return_value.call.return_value.timeout_happened = False
         adb_server = AdbServer('localhost', port=1000)
         resp = adb_server.execute('hello', 10)
         assert resp.return_code == 0


### PR DESCRIPTION
AdbServer:execute now verify that command was executed successfully (return_code == 0) and raises AssertionError if not. Raises also AssertionError if timeout happens. Increased default timeout from 2s to 10s.

no need to verify command return code anymore separately. 