### PR TITLE
fix syntax error when accessing device dict in stf cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     classifiers=CLASSIFIERS,
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "Appium-Python-Client",
+        "Appium-Python-Client<=3",
         "stf-client==0.1.0",
         "pydash",
         "easyprocess",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     classifiers=CLASSIFIERS,
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "Appium-Python-Client<=3",
+        "Appium-Python-Client<3",
         "stf-client==0.1.0",
         "pydash",
         "easyprocess",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     classifiers=CLASSIFIERS,
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "Appium-Python-Client<3",
+        "Appium-Python-Client",
         "stf-client==0.1.0",
         "pydash",
         "easyprocess",

--- a/stf_appium_client/cli.py
+++ b/stf_appium_client/cli.py
@@ -89,17 +89,17 @@ def main():
                     with AppiumServer(appium_args=appium_args, **extra_args) as appium:
                         appium.logger.info(f"appium server listening localhost:{appium.port}")
 
-                        appium.logger.info(f'Device in use: {device.manufacturer}:{device.marketName}, model: {device.model}, sn: {device.serial}')
+                        appium.logger.info(f'Device in use: {device["manufacturer"]}:{device["marketName"]}, model: {device["model"]}, sn: {device["serial"]}')
 
                         custom_env = {}
                         custom_env["DEV1_ADB_PORT"] = f"{adb.port}"
                         custom_env["DEV1_APPIUM_HOST"] = f'127.0.0.1:{appium.port}'
                         custom_env["DEV1_APPIUM_WD_HUB_URI"] = f'http://127.0.0.1:{appium.port}/wd/hub'
-                        custom_env["DEV1_SERIAL"] = device.serial
-                        custom_env["DEV1_VERSION"] = device.version
-                        custom_env["DEV1_MODEL"] = device.model
-                        custom_env["DEV1_MANUFACTURER"] = device.manufacturer
-                        custom_env["DEV1_MARKET_NAME"] = device.marketName
+                        custom_env["DEV1_SERIAL"] = device["serial"]
+                        custom_env["DEV1_VERSION"] = device["version"]
+                        custom_env["DEV1_MODEL"] = device["model"]
+                        custom_env["DEV1_MANUFACTURER"] = device["manufacturer"]
+                        custom_env["DEV1_MARKET_NAME"] = device["marketName"]
                         custom_env["DEV1_REQUIREMENTS"] = f"{requirement}"
                         custom_env["DEV1_INFO"] = json.dumps(device)
                         appium.logger.info('Env variables:')


### PR DESCRIPTION
Calling the stf cli will result in an error (e.g. 'dict' object has no attribute 'manufacturer'), because there is a syntax error when accessing the device dictionary.

This PR will fix this issue.