### PR TITLE
Revert "Lock for API calls"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,7 @@ setup(
         "stf-client==0.1.0",
         "pydash",
         "easyprocess",
-        "requests",
-        "pid"
+        "requests"
     ],
     entry_points={
         'console_scripts': [

--- a/stf_appium_client/StfClient.py
+++ b/stf_appium_client/StfClient.py
@@ -9,7 +9,6 @@ from stf_client.exceptions import ForbiddenException
 
 from stf_appium_client.Logger import Logger
 from stf_appium_client.exceptions import DeviceNotFound, NotConnectedError
-from stf_appium_client.tools import lock
 from stf_client.api_client import ApiClient, Configuration
 from stf_client.api.user_api import UserApi
 from stf_client.api.devices_api import DevicesApi
@@ -81,8 +80,7 @@ class StfClient(Logger):
         timeout = timeout_seconds * 1000
 
         api_instance = UserApi(self._client)
-        with lock():
-            api_response = api_instance.add_user_device_v2(serial, timeout=timeout)
+        api_response = api_instance.add_user_device_v2(serial, timeout=timeout)
         assert api_response.success, 'allocation fails'
         self.logger.info(f'{serial}: Allocated (timeout: {timeout_seconds})')
         device['owner'] = "me"
@@ -144,8 +142,7 @@ class StfClient(Logger):
         self.logger.debug(f'{serial}: releasing..')
 
         api_instance = UserApi(self._client)
-        with lock():
-            api_response = api_instance.delete_user_device_by_serial(serial)
+        api_response = api_instance.delete_user_device_by_serial(serial)
         assert api_response.success, 'release fails'
         device['owner'] = None
         self.logger.info(f'{serial}: released')

--- a/stf_appium_client/tools.py
+++ b/stf_appium_client/tools.py
@@ -1,9 +1,7 @@
 import socket
 import json
 import shutil
-import tempfile
-from contextlib import closing, contextmanager
-from pid import PidFile, PidFileError
+from contextlib import closing
 
 
 def find_free_port() -> int:
@@ -55,17 +53,3 @@ def parse_requirements(requirements_str: str) -> dict:
                     dest[subkey] = value
             split(requirements, key)
         return requirements
-
-@contextmanager
-def lock():
-    """
-    Master lock
-    """
-    try:
-        lockfile = PidFile(pidname='stf.pid', piddir=tempfile.gettempdir(), register_term_signal_handler=False)
-        lockfile.create()
-        yield lockfile
-    except PidFileError:
-        raise AssertionError('Lock in use')
-    finally:
-        lockfile.close()

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,8 +1,6 @@
 import json
-from unittest.mock import patch, MagicMock
 import pytest
-from stf_appium_client.tools import find_free_port, parse_requirements, lock
-from pid import PidFileAlreadyLockedError
+from stf_appium_client.tools import find_free_port, parse_requirements
 
 
 class TestTools:
@@ -30,25 +28,3 @@ class TestTools:
             self.assertEqual(parse_requirements("key="), {})
         with pytest.raises(ValueError):
             self.assertEqual(parse_requirements("="), {})
-
-    @patch('stf_appium_client.tools.PidFile')
-    def test_lock(self, mock_pidfile):
-        with lock():
-            self.assertEqual(mock_pidfile.return_value.create.call_count, 1)
-            self.assertEqual(mock_pidfile.return_value.close.call_count, 0)
-        self.assertEqual(mock_pidfile.return_value.close.call_count, 1)
-
-    @patch('stf_appium_client.tools.PidFile')
-    def test_lock_is_released(self, mock_pidfile):
-        try:
-            with lock():
-                raise RuntimeError()
-        except RuntimeError:
-            self.assertEqual(mock_pidfile.return_value.close.call_count, 1)
-
-    @patch('stf_appium_client.tools.PidFile')
-    def test_lock_in_use(self, mock_pidfile):
-        mock_pidfile.return_value.create.side_effect = [PidFileAlreadyLockedError()]
-        with pytest.raises(AssertionError):
-            with lock():
-                pass


### PR DESCRIPTION
Reverts OpenTMI/stf-appium-python-client#26 which was workaround for https://github.com/DeviceFarmer/stf/issues/620 - that is already fixed and released. No need to have such locking mechanism anymore and it leads other kind of trouble.