### PR TITLE
drop duplicate remote_connect call

### DIFF
--- a/stf_appium_client/StfClient.py
+++ b/stf_appium_client/StfClient.py
@@ -284,6 +284,5 @@ class StfClient(Logger):
         self.logger.info(f'device allocated: {device}')
         adb_adr = self.remote_connect(device)
         device['remote_adb_url'] = adb_adr
-        self.remote_connect(device)
         yield device
         self.release(device)


### PR DESCRIPTION
seems that remote_connect() was called twice in allocation_context even one should be enough.