### PR TITLE
feat: phone avoidance list

### DIFF
--- a/stf_appium_client/StfClient.py
+++ b/stf_appium_client/StfClient.py
@@ -188,9 +188,26 @@ class StfClient(Logger):
         return list(online)
 
 
+    def _prioritize_devices(self, devices: list, avoid_list) -> list:
+        """
+        Partition devices into preferred and avoided, returning preferred first.
+        Falls back to avoided devices if no preferred devices are available.
+
+        :param devices: list of device dicts (pre-shuffled by caller)
+        :param avoid_list: serials to deprioritize
+        :return: candidate list with preferred devices first, avoided as fallback
+        """
+        preferred = [d for d in devices if d.get('serial') not in avoid_list]
+        avoided = [d for d in devices if d.get('serial') in avoid_list]
+        self.logger.info(f'Avoidance logic active. Avoided serials: {list(avoid_list)}')
+        if not preferred:
+            self.logger.info('No preferred devices available, falling back to avoided devices')
+        return preferred if preferred else avoided
+
     def find_and_allocate(self, requirements: dict,
                           timeout_seconds: int = DEFAULT_ALLOCATION_TIMEOUT_SECONDS,
-                          shuffle: bool = True) -> dict:
+                          shuffle: bool = True,
+                          avoid_list=None) -> dict:
         """
         Find device based on requirements and allocate first.
         Note that this method doesn't wait for device to be free.
@@ -198,6 +215,7 @@ class StfClient(Logger):
         :param requirements: dictionary about requirements, e.g. `dict(platform='android')`
         :param timeout_seconds: allocation timeout when idle, see more from allocation api.
         :param shuffle: randomize allocation
+        :param avoid_list: serials to avoid unless no other device is available
         :return: device dictionary
 
         :raises DeviceNotFound: suitable device not found or all devices are allocated already
@@ -208,7 +226,8 @@ class StfClient(Logger):
         if shuffle:
             random.shuffle(suitable_devices)
 
-        self.logger.debug(f'Found {len(suitable_devices)} suitable devices, try to allocate one')
+        candidates = self._prioritize_devices(suitable_devices, avoid_list) if avoid_list else suitable_devices
+        self.logger.debug(f'Found {len(candidates)} candidate devices, try to allocate one')
 
         def try_allocate(device_candidate):
             try:
@@ -218,7 +237,7 @@ class StfClient(Logger):
                 return None
 
         # generate try_allocate tasks for suitable devices
-        tasks = map_(suitable_devices, lambda item: wrap(item, try_allocate))
+        tasks = map_(candidates, lambda item: wrap(item, try_allocate))
         # find first successful allocation
         result = find(tasks, lambda allocFunc: allocFunc())
 
@@ -229,13 +248,15 @@ class StfClient(Logger):
                                requirements: dict,
                                wait_timeout=60,
                                timeout_seconds=DEFAULT_ALLOCATION_TIMEOUT_SECONDS,
-                               shuffle: bool = True):
+                               shuffle: bool = True,
+                               avoid_list=None):
         """
         wait until suitable device is free and allocate it
         :param requirements: dict of requirements for DUT
         :param wait_timeout: wait timeout for suitable free device
         :param timeout_seconds: allocation timeout. See more from allocate -API.
         :param shuffle: allocate suitable device randomly.
+        :param avoid_list: serials to avoid unless no other device is available
         :return: device dictionary
         """
         wait_until = time.time() + wait_timeout
@@ -252,7 +273,8 @@ class StfClient(Logger):
             try:
                 return self.find_and_allocate(requirements=requirements,
                                               timeout_seconds=timeout_seconds,
-                                              shuffle=shuffle)
+                                              shuffle=shuffle,
+                                              avoid_list=avoid_list)
             except DeviceNotFound:
                 # Wait a while
                 self.logger.debug(f'Suitable device not available, '
@@ -267,19 +289,22 @@ class StfClient(Logger):
     def allocation_context(self, requirements: dict,
                            wait_timeout=60,
                            timeout_seconds: int = DEFAULT_ALLOCATION_TIMEOUT_SECONDS,
-                           shuffle: bool = True):
+                           shuffle: bool = True,
+                           avoid_list=None):
         """
         :param requirements:
         :param wait_timeout: how long time we try to allocate suitable device
         :param timeout_seconds: allocation timeout
         :param shuffle: allocate suitable device randomly
+        :param avoid_list: serials to avoid unless no other device is available
         :return:
         """
         self.logger.info(f"Trying to allocate device using requirements: {requirements}")
         device = self.find_wait_and_allocate(requirements=requirements,
                                              wait_timeout=wait_timeout,
                                              timeout_seconds=timeout_seconds,
-                                             shuffle=shuffle)
+                                             shuffle=shuffle,
+                                             avoid_list=avoid_list)
 
         self.logger.info(f'device allocated: {device}')
         adb_adr = self.remote_connect(device)

--- a/stf_appium_client/cli.py
+++ b/stf_appium_client/cli.py
@@ -53,6 +53,8 @@ def main():
                         help='appium logs to console. WARNING: this mix console prints')
     parser.add_argument('--appium-logs', metavar='file', type=str, default='',
                         help='appium logs to file')
+    parser.add_argument('--avoid-devices', metavar='S', type=str, default='',
+                        help='Comma-separated device serials to avoid unless no other device is available')
     parser.add_argument('command', nargs='*',
                         help='Command to be execute during device allocation')
 
@@ -75,9 +77,11 @@ def main():
         print(client.list_devices(requirements=requirement))
         exit(0)
 
+    avoid_list = args.avoid_devices.split(',') if args.avoid_devices else []
     with client.allocation_context(requirements=requirement,
                                    wait_timeout=args.wait_timeout,
-                                   timeout_seconds=args.timeout) as device:
+                                   timeout_seconds=args.timeout,
+                                   avoid_list=avoid_list) as device:
         try:
             with AdbServer(device['remote_adb_url']) as adb:
                 adb.logger.info(f'adb server listening localhost:{adb.port}')

--- a/test/test_StfClient.py
+++ b/test/test_StfClient.py
@@ -275,7 +275,8 @@ class TestPrioritizeDevices(unittest.TestCase):
         dev_a = self._make_device('AAA')
         dev_c = self._make_device('CCC')
         dev_avoided = self._make_device(avoided_serial)
-        result = self.client._prioritize_devices([dev_a, dev_c, dev_avoided], avoid_list=[avoided_serial])
+        # avoided first to ensure partitioning is what produces the correct order, not input order
+        result = self.client._prioritize_devices([dev_avoided, dev_a, dev_c], avoid_list=[avoided_serial])
         self.assertEqual(result, [dev_a, dev_c])
 
 
@@ -286,12 +287,15 @@ class TestPhoneAllocationPreference(TestStfClient):
         return {'serial': serial, 'present': True, 'ready': True,
                 'using': False, 'owner': None, 'status': 3}
 
-    def test_preferred_device_allocated_when_avoid_list_given(self):
+    @patch('random.shuffle')
+    def test_preferred_device_allocated_when_avoid_list_given(self, mock_shuffle):
         preferred = self._available('AAA')
         avoided = self._available('BBB')
-        self.client.get_devices = MagicMock(return_value=[preferred, avoided])
+        # avoided first: without partitioning, avoided would be tried first and the assertion would fail
+        self.client.get_devices = MagicMock(return_value=[avoided, preferred])
         self.client.allocate = MagicMock(return_value=preferred)
 
         self.client.find_and_allocate({}, avoid_list=[avoided['serial']])
 
+        mock_shuffle.assert_called()
         self.client.allocate.assert_called_once_with(preferred, timeout_seconds=900)

--- a/test/test_StfClient.py
+++ b/test/test_StfClient.py
@@ -241,3 +241,57 @@ class TestStfClient(unittest.TestCase):
             with self.client.allocation_context({"serial": '123'}, wait_timeout=10):
                 pass
         self.assertEqual(str(error.exception), 'Suitable device not found within 10s timeout ({"serial": "123"})')
+
+
+class TestPrioritizeDevices(unittest.TestCase):
+    """Unit tests for avoid-list partitioning logic"""
+
+    @classmethod
+    def setUpClass(cls):
+        logging.disable(logging.CRITICAL)
+
+    @classmethod
+    def tearDownClass(cls):
+        logging.disable(logging.NOTSET)
+
+    def setUp(self):
+        self.client = StfClient('localhost')
+
+    def _make_device(self, serial):
+        return {'serial': serial}
+
+    def test_falls_back_to_avoided_when_no_preferred(self):
+        devices = [self._make_device('AAA'), self._make_device('BBB')]
+        result = self.client._prioritize_devices(devices, avoid_list=[d['serial'] for d in devices])
+        self.assertEqual(result, devices)
+
+    def test_empty_avoid_list_returns_all_devices(self):
+        devices = [self._make_device('AAA'), self._make_device('BBB')]
+        result = self.client._prioritize_devices(devices, avoid_list=[])
+        self.assertEqual(result, devices)
+
+    def test_order_preserved_within_preferred(self):
+        avoided_serial = 'BBB'
+        dev_a = self._make_device('AAA')
+        dev_c = self._make_device('CCC')
+        dev_avoided = self._make_device(avoided_serial)
+        result = self.client._prioritize_devices([dev_a, dev_c, dev_avoided], avoid_list=[avoided_serial])
+        self.assertEqual(result, [dev_a, dev_c])
+
+
+class TestPhoneAllocationPreference(TestStfClient):
+    """Test phone allocation uses avoid-list"""
+
+    def _available(self, serial):
+        return {'serial': serial, 'present': True, 'ready': True,
+                'using': False, 'owner': None, 'status': 3}
+
+    def test_preferred_device_allocated_when_avoid_list_given(self):
+        preferred = self._available('AAA')
+        avoided = self._available('BBB')
+        self.client.get_devices = MagicMock(return_value=[preferred, avoided])
+        self.client.allocate = MagicMock(return_value=preferred)
+
+        self.client.find_and_allocate({}, avoid_list=[avoided['serial']])
+
+        self.client.allocate.assert_called_once_with(preferred, timeout_seconds=900)

--- a/test/test_StfClient.py
+++ b/test/test_StfClient.py
@@ -261,8 +261,11 @@ class TestPrioritizeDevices(unittest.TestCase):
         return {'serial': serial}
 
     def test_falls_back_to_avoided_when_no_preferred(self):
-        devices = [self._make_device('AAA'), self._make_device('BBB')]
-        result = self.client._prioritize_devices(devices, avoid_list=[d['serial'] for d in devices])
+        serial_a = 'AAA'
+        serial_b = 'BBB'
+        devices = [self._make_device(serial_a), self._make_device(serial_b)]
+        avoid_list = [serial_a, serial_b]
+        result = self.client._prioritize_devices(devices, avoid_list=avoid_list)
         self.assertEqual(result, devices)
 
     def test_empty_avoid_list_returns_all_devices(self):
@@ -272,16 +275,16 @@ class TestPrioritizeDevices(unittest.TestCase):
 
     def test_order_preserved_within_preferred(self):
         avoided_serial = 'BBB'
-        dev_a = self._make_device('AAA')
-        dev_c = self._make_device('CCC')
-        dev_avoided = self._make_device(avoided_serial)
+        device_a = self._make_device('AAA')
+        device_c = self._make_device('CCC')
+        device_avoided = self._make_device(avoided_serial)
         # avoided first to ensure partitioning is what produces the correct order, not input order
-        result = self.client._prioritize_devices([dev_avoided, dev_a, dev_c], avoid_list=[avoided_serial])
-        self.assertEqual(result, [dev_a, dev_c])
+        result = self.client._prioritize_devices([device_avoided, device_a, device_c], avoid_list=[avoided_serial])
+        self.assertEqual(result, [device_a, device_c])
 
 
 class TestPhoneAllocationPreference(TestStfClient):
-    """Test phone allocation uses avoid-list"""
+    """Test find_and_allocate uses avoid-list"""
 
     def _available(self, serial):
         return {'serial': serial, 'present': True, 'ready': True,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -32,15 +32,17 @@ class TestAdbServer:
             with patch.object(sys, 'argv', testargs):
                 main()
 
+    # skip adb check with CI env var
     @patch.dict(os.environ, {'CI': '1'})
     @patch('stf_appium_client.cli.StfClient')
     def test_avoid_devices_forwarded_to_allocation_context(self, mock_stf):
         avoid_devices = ['AAA', 'BBB']
         # Stop execution after allocation_context is called to avoid mocking AdbServer/AppiumServer
-        mock_stf.return_value.allocation_context.side_effect = SystemExit('test_stop')
+        test_stop_message = 'test_stop'
+        mock_stf.return_value.allocation_context.side_effect = SystemExit(test_stop_message)
         with patch.object(sys, 'argv', ["prog", "--token", "123", "--avoid-devices", ",".join(avoid_devices)]):
             with pytest.raises(SystemExit) as cm:
                 main()
-        assert cm.value.code == 'test_stop'
+        assert cm.value.code == test_stop_message
         _, kwargs = mock_stf.return_value.allocation_context.call_args
         assert kwargs.get('avoid_list') == avoid_devices

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 import urllib
 import pytest
@@ -30,3 +31,16 @@ class TestAdbServer:
         with pytest.raises(urllib3.exceptions.MaxRetryError):
             with patch.object(sys, 'argv', testargs):
                 main()
+
+    @patch.dict(os.environ, {'CI': '1'})
+    @patch('stf_appium_client.cli.StfClient')
+    def test_avoid_devices_forwarded_to_allocation_context(self, mock_stf):
+        avoid_devices = ['AAA', 'BBB']
+        # Stop execution after allocation_context is called to avoid mocking AdbServer/AppiumServer
+        mock_stf.return_value.allocation_context.side_effect = SystemExit('test_stop')
+        with patch.object(sys, 'argv', ["prog", "--token", "123", "--avoid-devices", ",".join(avoid_devices)]):
+            with pytest.raises(SystemExit) as cm:
+                main()
+        assert cm.value.code == 'test_stop'
+        _, kwargs = mock_stf.return_value.allocation_context.call_args
+        assert kwargs.get('avoid_list') == avoid_devices


### PR DESCRIPTION
Option to set avoidance list. When given, the devices are only allocated if no other device is available.
This way, targeted tests work with normal traffic, but allow fallback when resources are in heavy use